### PR TITLE
Feature: Add label filtering

### DIFF
--- a/src/components/label-filter/index.ts
+++ b/src/components/label-filter/index.ts
@@ -1,0 +1,1 @@
+export * from "./label-filter";

--- a/src/components/label-filter/label-filter.tsx
+++ b/src/components/label-filter/label-filter.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { Label } from "../labels";
+import { LabelFilterProps } from "./types";
+import { LabelWrapper, Wrapper } from "./ui";
+
+export const noLabel = {
+  id: "no-label",
+  color: "ffffff",
+  name: "No label"
+};
+
+export const LabelFilter = ({
+  labelData,
+  selectedLabel,
+  onLabelClick
+}: LabelFilterProps) => {
+  return (
+    <Wrapper>
+      {Object.entries(labelData).map(([id, label]) => {
+        return (
+          <LabelWrapper
+            key={id}
+            isActive={!selectedLabel.includes(id)}
+            onClick={() => onLabelClick(id)}
+          >
+            <Label {...label}>{label.name}</Label>
+          </LabelWrapper>
+        );
+      })}
+    </Wrapper>
+  );
+};

--- a/src/components/label-filter/types.ts
+++ b/src/components/label-filter/types.ts
@@ -1,0 +1,9 @@
+import { LabelNode } from "../labels/types";
+
+export type LabelFilterProps = {
+  labelData: {
+    [id: string]: LabelNode;
+  };
+  selectedLabel: string[];
+  onLabelClick: (labelId: string) => void;
+};

--- a/src/components/label-filter/ui.ts
+++ b/src/components/label-filter/ui.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  display: flex;
+  margin-bottom: 10px;
+`;
+
+export const LabelWrapper = styled.div`
+  cursor: pointer;
+  opacity: ${(props: { isActive: boolean }) => (props.isActive ? "1" : "0.5")};
+`;

--- a/src/components/projects/project.tsx
+++ b/src/components/projects/project.tsx
@@ -12,8 +12,8 @@ import {
 import { PULL_REQUESTS_BY_REPO_NAME } from "../../queries";
 import { useSettings } from "../../store/store";
 import { LoaderIcon } from "../loader-svg";
-import { PullRequest } from "../pull-request/";
-import { PullRequest as PrType } from "../pull-request/types";
+
+import { PullRequests } from "../pull-requets/pull-requests";
 
 export const Project = ({ repoName, orgName }: ProjectProps) => {
   const { actions, settings } = useSettings();
@@ -90,13 +90,7 @@ export const Project = ({ repoName, orgName }: ProjectProps) => {
           </a>
         </RepositoryName>
       </RepositoryNameWrapper>
-      {prs.length > 0 ? (
-        prs.map(({ node }: PrType) => <PullRequest key={node.id} {...node} />)
-      ) : (
-        <RegularMessage>
-          There are no PR's opened for this project.
-        </RegularMessage>
-      )}
+      <PullRequests prs={prs} projectId={repo.id} />
     </>
   );
 };

--- a/src/components/pull-request/pull-request.tsx
+++ b/src/components/pull-request/pull-request.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Labels } from "../labels/labels";
+
 import { dayjs } from "../../utils/date";
 import { PullRequestNode } from "./types";
 

--- a/src/components/pull-requets/index.ts
+++ b/src/components/pull-requets/index.ts
@@ -1,0 +1,1 @@
+export * from "./pull-requests";

--- a/src/components/pull-requets/pull-requests.tsx
+++ b/src/components/pull-requets/pull-requests.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+import { LabelFilter, noLabel } from "../label-filter";
+import { PullRequest } from "../pull-request";
+import { PullRequestsProps } from "./types";
+import { RegularMessage } from "../projects/ui";
+import { serializeLabelFromPrs } from "./utils";
+import { useSettings } from "../../store/store";
+
+export const PullRequests = ({ prs, projectId }: PullRequestsProps) => {
+  const { settings, actions } = useSettings();
+
+  function labelHandler(repoId: string) {
+    return (labelId: string) => {
+      actions.setFilteredLabels(repoId, labelId);
+    };
+  }
+
+  const filteredLabels = settings.filteredLabelsByRepoId[projectId] || [];
+
+  return (
+    <>
+      <LabelFilter
+        labelData={serializeLabelFromPrs(prs)}
+        selectedLabel={filteredLabels}
+        onLabelClick={labelHandler(projectId)}
+      />
+      {prs.length > 0 ? (
+        prs.map(({ node }) => {
+          const updatedNode = { ...node };
+
+          if (updatedNode.labels.edges.length === 0) {
+            updatedNode.labels.edges = [{ node: noLabel }];
+          }
+
+          const prLabels = updatedNode.labels.edges.map(label => label.node.id);
+          const shouldPrBeRendered = !prLabels.some(labelId =>
+            filteredLabels.includes(labelId)
+          );
+
+          if (shouldPrBeRendered) {
+            return <PullRequest key={node.id} {...updatedNode} />;
+          }
+          return null;
+        })
+      ) : (
+        <RegularMessage>
+          There are no PR's opened for this project.
+        </RegularMessage>
+      )}
+    </>
+  );
+};

--- a/src/components/pull-requets/types.ts
+++ b/src/components/pull-requets/types.ts
@@ -1,0 +1,6 @@
+import { PullRequest } from "../pull-request/types";
+
+export type PullRequestsProps = {
+  prs: PullRequest[];
+  projectId: string;
+};

--- a/src/components/pull-requets/utils.ts
+++ b/src/components/pull-requets/utils.ts
@@ -1,0 +1,14 @@
+import { PullRequest } from "../pull-request/types";
+
+export function serializeLabelFromPrs(prs: PullRequest[]) {
+  return prs.reduce((acc: any, current: PullRequest) => {
+    const { labels } = current.node;
+
+    labels.edges.forEach(label => {
+      const { node } = label;
+      acc[node.id] = { ...node };
+    });
+
+    return acc;
+  }, {});
+}

--- a/src/store/actionCreators.ts
+++ b/src/store/actionCreators.ts
@@ -15,6 +15,15 @@ export function actionsCreator(dispatch: React.Dispatch<Action>) {
     },
     setOrgData(orgData: Organization) {
       dispatch({ type: ActionTypesEnum.SET_ORG_DATA, payload: orgData });
+    },
+    setFilteredLabels(repoId: string, labelId: string) {
+      dispatch({
+        type: ActionTypesEnum.UPDATE_FILTERED_LABELS_BY_REPO,
+        payload: {
+          repoId,
+          labelId
+        }
+      });
     }
   };
 }

--- a/src/store/localStorage.ts
+++ b/src/store/localStorage.ts
@@ -9,13 +9,20 @@ enum COOKIE_KEYS {
   ORG_NAME = "pr_tracker_org_name"
 }
 
+enum LOCAL_STORAGE_KEYS {
+  LABEL_BY_REPO = "pr_tracker_label_by_repo"
+}
+
 export function getSettings(): PartialSettings | {} {
   if (process.browser) {
     const apiToken = Cookies.get(COOKIE_KEYS.API_TOKEN);
     const orgName = Cookies.get(COOKIE_KEYS.ORG_NAME);
     const repos = Cookies.get(COOKIE_KEYS.REPOS);
+    const filteredLabelsByRepoId = JSON.parse(
+      localStorage.getItem(LOCAL_STORAGE_KEYS.LABEL_BY_REPO) || "{}"
+    );
 
-    return { apiToken, orgName, repos };
+    return { apiToken, orgName, repos, filteredLabelsByRepoId };
   }
   return {};
 }
@@ -27,5 +34,14 @@ export function setSettings(settings: Settings) {
     Cookies.set(COOKIE_KEYS.API_TOKEN, apiToken);
     Cookies.set(COOKIE_KEYS.REPOS, repos);
     Cookies.set(COOKIE_KEYS.ORG_NAME, orgName);
+  }
+}
+
+export function setLabelsByRepo(labelsByRepo: { [id: string]: string[] }) {
+  if (process.browser) {
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.LABEL_BY_REPO,
+      JSON.stringify(labelsByRepo)
+    );
   }
 }

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,11 +1,13 @@
 import { getRepoList } from "../utils/github";
 
-import { Settings, Repository, Organization } from "../types";
+import { Settings, Repository, Organization, LabelToSave } from "../types";
+import { setLabelsByRepo } from "./localStorage";
 
 export enum ActionTypesEnum {
   UPDATE_SETTINGS = "UPDATE_SETTINGS",
   ADD_REPO = "ADD_REPO",
-  SET_ORG_DATA = "SET_ORG_DATA"
+  SET_ORG_DATA = "SET_ORG_DATA",
+  UPDATE_FILTERED_LABELS_BY_REPO = "UPDATE_FILTERED_LABELS_BY_REPO"
 }
 
 export const initialState = {
@@ -14,12 +16,13 @@ export const initialState = {
   repos: "",
   reposList: [],
   orgData: {},
-  repositories: {}
+  repositories: {},
+  filteredLabelsByRepoId: {}
 };
 
 export type Action = {
   type: ActionTypesEnum;
-  payload: Settings | Repository | Organization;
+  payload: Settings | Repository | Organization | LabelToSave;
 };
 
 export function reducer(state: Settings, action: Action) {
@@ -49,6 +52,21 @@ export function reducer(state: Settings, action: Action) {
     case ActionTypesEnum.SET_ORG_DATA: {
       const orgData = action.payload as Organization;
       return { ...state, orgData };
+    }
+    case ActionTypesEnum.UPDATE_FILTERED_LABELS_BY_REPO: {
+      const { labelId, repoId } = action.payload as LabelToSave;
+      const nextState = { ...state };
+      const byId = nextState.filteredLabelsByRepoId[repoId] || [];
+
+      const cu = byId.includes(labelId)
+        ? byId.filter(id => id !== labelId)
+        : byId.concat(labelId);
+
+      nextState.filteredLabelsByRepoId[repoId] = cu;
+
+      setLabelsByRepo(nextState.filteredLabelsByRepoId);
+
+      return { ...nextState };
     }
     default:
       throw new Error("UNTRACKED ACTION TYPE");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from "./organization";
 export * from "./pull-requests";
 export * from "./repository";
 export * from "./settings";
+export * from "./label";

--- a/src/types/label.ts
+++ b/src/types/label.ts
@@ -1,0 +1,1 @@
+export type LabelToSave = { repoId: string; labelId: string };

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -8,6 +8,9 @@ export type PartialSettings = {
 };
 
 export type Settings = PartialSettings & {
+  filteredLabelsByRepoId: {
+    [repoId: string]: string[];
+  };
   reposList: string[];
   orgData: Organization;
   repositories: { [repoName: string]: Repository };


### PR DESCRIPTION
Now for each project, it knows what labels are present and based on that, show or not certain PR.

When it selects a select or unselect a label, it saves on `localStorage` those selections to avoid user refresh the page and lost every filter for each project.
 
Closes #3